### PR TITLE
feat: 框架级通用改进（Provider 发送扩展接口 / 流式稳定性双通道 / 自定义 Provider 渲染进程加载）

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -65,6 +65,7 @@ function createWindow(profile) {
       sandbox: false,
       partition: profileData.partition, // 每个 profile 独立持久化 session
       backgroundThrottling: false,
+      additionalArguments: ['--cuckoo-user-data=' + app.getPath('userData')],
     },
   });
 

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -37,7 +37,16 @@ function registerIpcHandlers() {
     const ctx = windowState.getContextByWebContents(event.sender);
     const win = ctx ? ctx.win : null;
     if (!win || win.isDestroyed()) return { success: false, error: '窗口已关闭' };
-    const url = 'https://chat.deepseek.com/a/chat/s/' + sessionId;
+    // 按当前 provider 拼会话 URL（智谱 cid=、DeepSeek /chat/s/、Claude /chat/）
+    let url = null;
+    try {
+      const { getProviderByUrl } = require('../providers');
+      const provider = getProviderByUrl(win.webContents.getURL());
+      if (provider && typeof provider.sessionUrlBase === 'string' && provider.sessionUrlBase) {
+        url = provider.sessionUrlBase + sessionId;
+      }
+    } catch (_) { /* 回退 DeepSeek */ }
+    if (!url) url = 'https://chat.deepseek.com/a/chat/s/' + sessionId;
     try {
       await win.webContents.loadURL(url);
       return { success: true };
@@ -156,6 +165,21 @@ function registerIpcHandlers() {
       return { callId, ...result };
     } catch (err) {
       return { callId, success: false, error: err.message };
+    }
+  });
+
+  // 站点原生发送：向聚焦输入框注入真实级 Enter（智谱只响应 isTrusted=true 的输入，合成事件免疫）
+  ipcMain.handle('chat-send-enter', async (event) => {
+    const sender = event.sender;
+    if (!sender || sender.isDestroyed()) return false;
+    try {
+      sender.sendInputEvent({ type: 'keyDown', keyCode: 'Return', key: 'Enter' });
+      sender.sendInputEvent({ type: 'char', keyCode: 'Return', key: '\r' });
+      sender.sendInputEvent({ type: 'keyUp', keyCode: 'Return', key: 'Enter' });
+      return true;
+    } catch (err) {
+      console.error('[Cuckoo Code] ❌ 原生 Enter 发送失败:', err.message);
+      return false;
     }
   });
 }

--- a/src/main/session-store.js
+++ b/src/main/session-store.js
@@ -4,6 +4,7 @@
  */
 const fs = require('fs');
 const path = require('path');
+const { getProviderByUrl } = require('../providers');
 
 /**
  * 创建 profile 专属的 session store 实例
@@ -49,6 +50,14 @@ function createSessionStore(profileId, storeDir, windowState) {
 
   function extractSessionIdFromUrl(url) {
     if (!url) return null;
+    // 平台 provider 优先（智谱 cid=、Claude /chat/ 等）
+    try {
+      const provider = getProviderByUrl(url);
+      if (provider && typeof provider.extractSessionId === 'function') {
+        const sid = provider.extractSessionId(url);
+        if (sid) return sid;
+      }
+    } catch (_) { /* provider 异常时回退旧逻辑 */ }
     // Claude: https://claude.ai/chat/xxx
     if (url.includes('claude.ai')) {
       const m = url.match(/\/chat\/([a-zA-Z0-9_-]+)/i);

--- a/src/preload/api.js
+++ b/src/preload/api.js
@@ -22,6 +22,9 @@ let electronAPI = {
   executeJs: (code, callId) => {
     return ipcRenderer.invoke('execute-js', { code, callId });
   },
+  sendEnterToChat: () => {
+    return ipcRenderer.invoke('chat-send-enter');
+  },
   listSessions: () => {
     return ipcRenderer.invoke('list-sessions');
   },
@@ -94,4 +97,3 @@ try {
 
 // 无论 contextBridge 是否成功，都直接挂载到 window 作为备选
 window.electronAPI = electronAPI;
-

--- a/src/preload/dom/chat-input.js
+++ b/src/preload/dom/chat-input.js
@@ -224,6 +224,33 @@ function waitForInitialPromptAndSend() {
 function triggerSend(input) {
   const provider = getCurrentProvider();
 
+  // 方法 0: 站点原生发送（智谱等免疫合成事件的平台，经主进程注入真实级输入）
+  if (provider && typeof provider.triggerSend === 'function') {
+    let result = null;
+    try { result = provider.triggerSend(input); } catch (_) { /* 站点实现异常时回退通用逻辑 */ }
+    if (result && typeof result.then === 'function') {
+      result.then(function (ok) {
+        if (ok) {
+          console.log('[Cuckoo Code] 已通过站点原生发送触发');
+        } else {
+          fallbackSend(provider, input);
+        }
+      }).catch(function () { fallbackSend(provider, input); });
+      return;
+    }
+    if (result) {
+      console.log('[Cuckoo Code] 已通过站点原生发送触发');
+      return;
+    }
+  }
+
+  fallbackSend(provider, input);
+}
+
+/**
+ * 通用发送兜底：查找发送按钮点击，或模拟 Enter 按键序列
+ */
+function fallbackSend(provider, input) {
   // 方法 1: 调用平台 Provider 查找发送按钮
   if (provider && typeof provider.findSendButton === 'function') {
     const btn = provider.findSendButton();

--- a/src/preload/dom/js-detector.js
+++ b/src/preload/dom/js-detector.js
@@ -21,7 +21,13 @@ function looksLikeIncompleteCodeError(error) {
 
 function looksLikeToolScript(code) {
   const c = code || '';
-  return JS_TOOL_CALL_RE.test(c);
+  // 1. 内置工具白名单：await write( 等
+  if (JS_TOOL_CALL_RE.test(c)) return true;
+  // 2. MCP 工具：await mcpXxx(（MCP server 工具名动态，无法进白名单，按 mcp 前缀识别）
+  if (/\bawait\s+mcp[A-Za-z_$][\w$]*\s*\(/.test(c)) return true;
+  // 3. Cuckoo 输出封装：log(await xxx( ...（log 包裹的任意工具调用，含 MCP）
+  if (/\blog\s*\(\s*await\s+[A-Za-z_$][\w$]*\s*\(/.test(c)) return true;
+  return false;
 }
 
 /**
@@ -106,7 +112,7 @@ function hasOnlyCodeContent(root) {
   if (root.tagName === 'PRE') return true;
   const clone = root.cloneNode(true);
   // 剔除代码块本身、banner（语言标签 + 复制/下载按钮）与工具栏等装饰元素
-  clone.querySelectorAll('pre, .md-code-block-banner-wrap, .md-code-block-banner, button, [class*="toolbar"], [class*="copy"], [class*="download"], [class*="code-block-header"], [class*="lang"], [class*="header"]').forEach((el) => el.remove());
+  clone.querySelectorAll('pre, .md-code, .md-code-block-banner-wrap, .md-code-block-banner, button, [class*="toolbar"], [class*="copy"], [class*="download"], [class*="code-block-header"], [class*="lang"], [class*="header"]').forEach((el) => el.remove());
   return !(clone.textContent || '').trim();
 }
 
@@ -125,6 +131,11 @@ function getJsCodeBlocksFromMarkdown(root) {
   if (root.querySelectorAll) {
     const nested = root.querySelectorAll('pre');
     for (const p of nested) pres.push(p);
+    // 兜底：无 <pre> 的代码容器（如智谱 .md-code 用 div + highlight.js span 渲染）
+    if (pres.length === 0) {
+      const mdCodes = root.querySelectorAll('.md-code');
+      for (const c of mdCodes) pres.push(c);
+    }
   }
 
   for (const pre of pres) {
@@ -136,7 +147,13 @@ function getJsCodeBlocksFromMarkdown(root) {
       blocks.push(code);
       continue;
     }
-    if ((lang === 'js' || lang === 'javascript' || lang === '') && onlyCode && looksLikeToolScript(code)) {
+    if (lang === 'js' || lang === 'javascript') {
+      if (onlyCode && looksLikeToolScript(code)) blocks.push(code);
+      continue;
+    }
+    // 语言未知（智谱等无语言标签站点）：代码明确以工具调用开头（await <工具>(）即视为工具脚本
+    // 走 JS 块路径以获得稳定性校验（流式渲染期间不会执行半截代码）
+    if (lang === '' && looksLikeToolScript(code)) {
       blocks.push(code);
     }
   }

--- a/src/preload/dom/observer.js
+++ b/src/preload/dom/observer.js
@@ -64,8 +64,10 @@ async function handleManualParse() {
 // 已处理过的消息节点集合（避免重复处理）
 let processedMessages = new WeakSet();
 
-// 正在做 JS 代码块稳定性校验的消息，防止 800ms 窗口内被重复调度
-let pendingJsChecks = new WeakSet();
+// JS 代码块稳定性校验状态：msg → {snapshot, blocksSig, lastChange}
+// 由 mutation 驱动更新；interval 兜底在内容稳定满窗口后执行，不依赖单次 setTimeout（智谱等 SPA 下不可靠）
+let jsStability = new Map();
+let stabilityTimer = null;
 
 // 连续 XML 提示次数（防止 AI 持续用 XML 格式回复导致无限循环）
 let xmlHintCount = 0;
@@ -74,7 +76,11 @@ const XML_HINT_MAX = 10;
 // 重置已处理状态（URL 切换/新会话时调用）
 function resetProcessedState() {
   processedMessages = new WeakSet();
-  pendingJsChecks = new WeakSet();
+  jsStability = new Map();
+  if (stabilityTimer) {
+    clearInterval(stabilityTimer);
+    stabilityTimer = null;
+  }
   xmlHintCount = 0;
 }
 
@@ -82,8 +88,10 @@ function resetProcessedState() {
 const MAX_RETRY_COUNT = 2;
 // 重试间隔（ms）
 const RETRY_INTERVAL = 2000;
-// JS 代码块稳定性校验的最大复查次数（1.2 秒/次，约 48 秒）
-const JS_STABILITY_MAX_RETRY = 40;
+// JS 代码块稳定确认窗口（ms）
+const JS_STABILITY_WINDOW = 800;
+// interval 兜底轮询间隔（ms）
+const STABILITY_POLL_INTERVAL = 500;
 /**
  * 检查字符串是否为"疑似工具调用但内容不完整"
  * 规则：文本包含 { 且含工具调用特征（toolName/工具名/大括号开头），
@@ -182,6 +190,36 @@ async function executeJsBlocksWithRetry(initialBlocks, markdown, force) {
   }
   if (results.length > 0) sendCombinedJsResultsToChat(results);
 }
+/**
+ * 稳定性 interval 兜底：mutation 驱动可能因 SPA 宏任务风暴而漏触发，
+ * 这里每 STABILITY_POLL_INTERVAL 检查一次，内容稳定满 JS_STABILITY_WINDOW 即执行。
+ * 与 mutation 通道共享 jsStability 快照；执行后按消息预标记，防止双通道重复处理。
+ */
+function ensureStabilityTimer() {
+  if (stabilityTimer) return;
+  stabilityTimer = setInterval(() => {
+    const now = Date.now();
+    for (const [msg, rec] of jsStability) {
+      // 节点已被页面卸载：清理
+      if (typeof msg.isConnected === 'boolean' && !msg.isConnected) {
+        jsStability.delete(msg);
+        continue;
+      }
+      if (now - rec.lastChange >= JS_STABILITY_WINDOW) {
+        jsStability.delete(msg);
+        if (processedMessages.has(msg)) continue; // 已被其他通道处理
+        processedMessages.add(msg);
+        // 内容已稳定满窗口 → force 直接执行（避免重新 set 快照导致死循环）
+        processLatestAIResponse(0, true);
+      }
+    }
+    if (jsStability.size === 0) {
+      clearInterval(stabilityTimer);
+      stabilityTimer = null;
+    }
+  }, STABILITY_POLL_INTERVAL);
+}
+
 
 /**
  * 回复结束后，获取最新一条 AI 回复的内容并解析工具调用
@@ -238,47 +276,64 @@ function processLatestAIResponse(retryCount = 0, force = false) {
     ' force=' + force +
     ' retryCount=' + retryCount);
   if (jsBlocks.length > 0) {
-    // 稳定性双读校验：DeepSeek 流式渲染期间代码块只渲染了一半（曾导致 "const content"
-    // 这样的残缺代码被执行 → SyntaxError）。间隔 1.2 秒复查内容，仍在变化就重新调度。
-    if (!force && pendingJsChecks.has(lastMessage)) {
-      console.log('[Cuckoo Code] ⏭ 该消息已在稳定性校验中，跳过重复调度');
-      return;
-    }
-    if (!force) pendingJsChecks.add(lastMessage);
-    if (!force && retryCount > JS_STABILITY_MAX_RETRY) {
-      console.log('[Cuckoo Code] ⚠️ 代码块持续不稳定（' + retryCount + ' 次复查），放弃本次处理');
-      pendingJsChecks.delete(lastMessage);
-      processedMessages.add(lastMessage);
-      return;
-    }
-    const snapshot = markdown.textContent || '';
-    const snapshotBlocks = jsBlocks.map((b) => b.length).join(',');
-    console.log('[Cuckoo Code] ⏳ 检测到 JS 工具代码块，稳定性校验中（' + (retryCount + 1) + '/' + JS_STABILITY_MAX_RETRY + '）...');
+    // 稳定性双通道校验：流式渲染期间代码块只渲染了一半（曾导致 "const content"
+    // 这样的残缺代码被执行 → SyntaxError）。mutation 驱动 + interval 兜底，
+    // 内容稳定满 JS_STABILITY_WINDOW 后执行，不依赖单次 setTimeout（智谱等 SPA 下不可靠）。
     if (force) {
+      // 手动解析：跳过稳定性校验，直接执行（标记已处理，避免同节点重复自动执行）
+      processedMessages.add(lastMessage);
       console.log('[Cuckoo Code] 手动解析模式，跳过稳定性校验');
       executeJsBlocksWithRetry(jsBlocks, markdown, true);
       return;
     }
 
-    setTimeout(() => {
-      const jsBlocksNow = getJsCodeBlocksFromMarkdown(markdown);
-      const stable = (markdown.textContent || '') === snapshot &&
-        jsBlocksNow.length === jsBlocks.length &&
-        jsBlocksNow.map((b) => b.length).join(',') === snapshotBlocks;
-      if (!stable) {
-        console.log('[Cuckoo Code] ⏳ 代码块仍在流式更新（快照不一致），重新调度');
-        pendingJsChecks.delete(lastMessage);
-        processLatestAIResponse(retryCount + 1);
-        return;
-      }
-      if (!force) processedMessages.add(lastMessage);
-      pendingJsChecks.delete(lastMessage);
-      console.log('[Cuckoo Code] ✅ 代码块稳定，检测到 JS 工具代码块（' + jsBlocks.length + ' 个），开始执行');
-      // 正确使用 cuckoo 代码块，重置 XML 提示计数
-      xmlHintCount = 0;
-      executeJsBlocksWithRetry(jsBlocks, markdown, false);
-    }, 800);
+    const snapshot = markdown.textContent || '';
+    const blocksSig = jsBlocks.map((b) => b.length).join(',');
+    const now = Date.now();
+    const rec = jsStability.get(lastMessage);
+    if (!rec || rec.snapshot !== snapshot || rec.blocksSig !== blocksSig) {
+      // 内容仍在变化：记录快照，等待下一次 mutation / interval 复查
+      jsStability.set(lastMessage, { snapshot, blocksSig, lastChange: now });
+      ensureStabilityTimer();
+      console.log('[Cuckoo Code] ⏳ 检测到 JS 工具代码块，流式渲染中，等待稳定...');
+      return; // 不标记 processed，稳定后执行
+    }
+
+    // 内容一致：需稳定满窗口确认
+    if (now - rec.lastChange < JS_STABILITY_WINDOW) {
+      console.log('[Cuckoo Code] ⏳ JS 代码块稳定中（等待 ' + JS_STABILITY_WINDOW + 'ms 确认）...');
+      return;
+    }
+
+    // 稳定满窗口 → 执行
+    jsStability.delete(lastMessage);
+    processedMessages.add(lastMessage);
+    console.log('[Cuckoo Code] ✅ 代码块稳定，检测到 JS 工具代码块（' + jsBlocks.length + ' 个），开始执行');
+    // 正确使用 cuckoo 代码块，重置 XML 提示计数
+    xmlHintCount = 0;
+    executeJsBlocksWithRetry(jsBlocks, markdown, false);
     return;
+  }
+
+  // 无 JS 代码块：文本也可能仍在流式渲染中（先文字后代码块 / 代码块中途不完整）。
+  // 若直接处理，会因"疑似工具但未识别"或"普通文本"提前标记 processed，
+  // 导致同一条消息后续渲染出的完整代码块被永久跳过（智谱等 SPA 回复中途
+  // isResponseComplete 即可能返回 true）。与 JS 块共用稳定性通道。
+  if (!force) {
+    const snapshot = markdown.textContent || '';
+    const now = Date.now();
+    const rec = jsStability.get(lastMessage);
+    if (!rec || rec.snapshot !== snapshot) {
+      jsStability.set(lastMessage, { snapshot, blocksSig: 'text', lastChange: now });
+      ensureStabilityTimer();
+      console.log('[Cuckoo Code] ⏳ 文本内容渲染中，等待稳定（防流式中途漏检）...');
+      return;
+    }
+    if (now - rec.lastChange < JS_STABILITY_WINDOW) {
+      console.log('[Cuckoo Code] ⏳ 文本内容稳定中（等待 ' + JS_STABILITY_WINDOW + 'ms 确认）...');
+      return;
+    }
+    jsStability.delete(lastMessage);
   }
 
   // 提取文本：优先从 pre code 提取（代码块内容天然不含 json/复制/下载等按钮文字）
@@ -399,13 +454,19 @@ function processLatestAIResponse(retryCount = 0, force = false) {
       }
     } else {
       console.log('[Cuckoo Code] ℹ️ 正常文本回复，未检测到工具调用（无需处理）');
-      window.electronAPI.showAiNotification().catch(() => {});
+      // 防重复：同一文本不重复通知（完成检测轮询每 2s 触发一次，避免刷屏）
+      if (lastNotifiedText !== text) {
+        lastNotifiedText = text;
+        window.electronAPI.showAiNotification().catch(() => {});
+      }
     }
   }
 }
 // 读取防抖定时器（已弃用，改用 Promise sleep + 处理中标志位）
 let isProcessingResponse = false;
 let lastObserverRun = 0;
+let completionPollTimer = null;
+let lastNotifiedText = '';
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -459,6 +520,23 @@ function startObserver() {
   const target = document.body || document.documentElement;
   if (target) {
     observer.observe(target, { childList: true, subtree: true, characterData: true, attributes: true });
+  }
+
+  // 完成检测兜底轮询：mutation 通道存在漏触发窗口——
+  // 长回复期间"停止对话"按钮常驻使 isAIResponseComplete 持续 false，生成结束按钮消失
+  // 这一完成信号若恰好落在 100ms 节流 / isProcessingResponse 串行窗口内会被丢弃，
+  // 之后无新 DOM 变化则永久不触发。定期主动复查一次，覆盖长生成场景。
+  if (!completionPollTimer) {
+    completionPollTimer = setInterval(() => {
+      if (isProcessingResponse) return;
+      (async () => {
+        try {
+          if (await isAIResponseComplete()) {
+            processLatestAIResponse();
+          }
+        } catch (_) { /* 轮询失败静默，等待下一轮 */ }
+      })();
+    }, 2000);
   }
 }
 
@@ -633,4 +711,3 @@ module.exports = {
   handleToolCall,
   handleManualParse,
 };
-

--- a/src/providers/custom/loader.js
+++ b/src/providers/custom/loader.js
@@ -7,24 +7,43 @@ const fs = require('fs');
 const path = require('path');
 const { app } = require('electron');
 
-// preload 渲染进程无法访问 electron.app（app 为 undefined），
-// 而 providers 模块会在渲染进程被 require 后立即加载自定义 Provider，
-// 导致不停打印 "Cannot read properties of undefined (reading 'getPath')"。
-// 渲染进程只需内置 Provider 的 URL 匹配能力，因此直接跳过自定义 Provider 加载。
-const isRenderer = process.type === 'renderer';
+// 渲染进程无法访问 electron.app（app 为 undefined），但页面内的自动解析/发送需要
+// 自定义 Provider 的方法（isResponseComplete 等），不能只靠内置 Provider。
+// 渲染进程的 userData 路径由主进程在创建窗口时经 additionalArguments 注入
+// （--cuckoo-user-data=），据此读取配置并加载自定义 Provider。
+function isRendererProcess() {
+  return process.type === 'renderer';
+}
+
+// 缓存：完成检测轮询等高频路径每 2s 调用一次 loadCustomProviders，避免反复 require 与刷屏
+let customProviderCache = null;
+function invalidateCustomProviderCache() {
+  customProviderCache = null;
+}
 
 const CUSTOM_CONFIG_FILE = 'custom-providers.json';
 const CUSTOM_PROVIDERS_DIR = 'custom-providers';
 
+function getUserDataPath() {
+  if (!isRendererProcess() && app && typeof app.getPath === 'function') {
+    return app.getPath('userData');
+  }
+  const arg = (process.argv || []).find((a) => a.startsWith('--cuckoo-user-data='));
+  return arg ? arg.slice('--cuckoo-user-data='.length) : null;
+}
+
 function getConfigPath() {
-  return path.join(app.getPath('userData'), CUSTOM_CONFIG_FILE);
+  const base = getUserDataPath();
+  return base ? path.join(base, CUSTOM_CONFIG_FILE) : null;
 }
 
 function getCustomProvidersDir() {
-  return path.join(app.getPath('userData'), CUSTOM_PROVIDERS_DIR);
+  const base = getUserDataPath();
+  return base ? path.join(base, CUSTOM_PROVIDERS_DIR) : null;
 }
 
 function ensureCustomProvidersDir() {
+  if (isRendererProcess()) return null;
   const dir = getCustomProvidersDir();
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
@@ -33,9 +52,9 @@ function ensureCustomProvidersDir() {
 }
 
 function readConfig() {
-  if (isRenderer) return { paths: [] };
   try {
     const file = getConfigPath();
+    if (!file) return { paths: [] };
     if (fs.existsSync(file)) {
       return JSON.parse(fs.readFileSync(file, 'utf-8'));
     }
@@ -46,6 +65,7 @@ function readConfig() {
 }
 
 function writeConfig(config) {
+  if (isRendererProcess()) return;
   try {
     fs.writeFileSync(getConfigPath(), JSON.stringify(config, null, 2), 'utf-8');
   } catch (err) {
@@ -71,7 +91,7 @@ function loadProviderFromFile(filePath) {
 }
 
 function loadCustomProviders() {
-  if (isRenderer) return [];
+  if (customProviderCache) return customProviderCache;
   const config = readConfig();
   const providers = [];
   for (const p of config.paths || []) {
@@ -93,6 +113,7 @@ function loadCustomProviders() {
       console.error('[CustomProvider] 加载失败:', p, err.message);
     }
   }
+  customProviderCache = providers;
   return providers;
 }
 
@@ -124,9 +145,10 @@ function importCustomProvider(sourcePath, options = {}) {
   // 复制到 userData/custom-providers/
   fs.copyFileSync(sourcePath, targetPath);
 
-  // 写配置
+  // 写配置（导入/替换都会改变 provider 集合，无条件失效缓存）
   const config = readConfig();
   if (!config.paths) config.paths = [];
+  invalidateCustomProviderCache();
   if (!config.paths.includes(targetPath)) {
     config.paths.push(targetPath);
   }
@@ -171,9 +193,11 @@ function removeCustomProviderPath(filePath) {
       console.error('[CustomProvider] 删除文件失败:', filePath, err.message);
     }
   }
+  invalidateCustomProviderCache();
 }
 
 module.exports = {
+  invalidateCustomProviderCache,
   loadCustomProviders,
   importCustomProvider,
   replaceCustomProvider,

--- a/test/main/providers.test.js
+++ b/test/main/providers.test.js
@@ -98,3 +98,35 @@ test('claude getMessageMarkdown 优先 standard-markdown', () => {
   };
   assert.strictEqual(claude.getMessageMarkdown(msg), 'STD');
 });
+
+test('渲染进程经注入的 userData 路径可加载自定义 Provider', () => {
+  const os = require('node:os');
+  const path = require('node:path');
+  const fs = require('node:fs');
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cuckoo-cp-'));
+  const dir = path.join(tmp, 'custom-providers');
+  fs.mkdirSync(dir, { recursive: true });
+  const providerFile = path.join(dir, 'demo.js');
+  fs.writeFileSync(providerFile,
+    "module.exports = { id: 'demo', name: 'Demo', homeUrl: 'https://demo.example.com', " +
+    "matchesUrl: (u) => String(u).includes('demo.example.com'), extractSessionId: () => '1' };");
+  fs.writeFileSync(path.join(tmp, 'custom-providers.json'),
+    JSON.stringify({ paths: [providerFile.replace(/\\/g, '/')] }));
+
+  const savedArgv = process.argv;
+  const savedType = process.type;
+  process.type = 'renderer';
+  process.argv = savedArgv.concat(['--cuckoo-user-data=' + tmp]);
+  const loaderPath = require.resolve('../../src/providers/custom/loader');
+  delete require.cache[loaderPath];
+  try {
+    const { loadCustomProviders } = require(loaderPath);
+    const ps = loadCustomProviders();
+    assert.ok(ps.some((p) => p.id === 'demo'), '渲染进程应能加载注入路径下的自定义 Provider');
+  } finally {
+    process.type = savedType;
+    process.argv = savedArgv;
+    delete require.cache[loaderPath];
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/preload/js-detector.test.js
+++ b/test/preload/js-detector.test.js
@@ -81,3 +81,114 @@ test('getJsCodeBlocksFromMarkdown PRE 元素', () => {
   const blocks = getJsCodeBlocksFromMarkdown(fakePre);
   assert.deepStrictEqual(blocks, ['await read("a")']);
 });
+
+
+// ========== 智谱场景（2026-09-07 修复回归） ==========
+// 智谱 .md-code 用 div + highlight.js span 渲染，语言标签定位不到（lang=''）：
+// 1) 无 <pre> 时兜底 .md-code 容器；2) lang='' 时代码以工具调用开头即提取（不限 onlyCode）
+
+function makeFakeRoot({ textOnly, codeText, langAttr, hasPre }) {
+  const codeEl = hasPre
+    ? {
+        tagName: 'CODE',
+        textContent: codeText,
+        querySelectorAll: () => [],
+        querySelector: () => null,
+        closest: () => null,
+        getAttribute: () => null,
+        classList: [],
+      }
+    : null;
+  const block = {
+    tagName: hasPre ? 'PRE' : 'DIV',
+    className: hasPre ? '' : 'markdown-body md-code',
+    textContent: codeText,
+    querySelector: (sel) => (sel === 'code' ? codeEl : null),
+    querySelectorAll: () => [],
+    closest: () => null,
+    getAttribute: (n) => (n === 'data-language' ? langAttr || null : null),
+    classList: [],
+    remove: () => {},
+  };
+  return {
+    tagName: 'DIV',
+    textContent: (textOnly || '') + ' ' + codeText,
+    cloneNode: () => ({
+      textContent: textOnly || '',
+      querySelectorAll: () => (textOnly ? [] : [block]),
+    }),
+    querySelectorAll: (sel) => (sel === 'pre' ? (hasPre ? [block] : []) : sel === '.md-code' ? [block] : []),
+  };
+}
+
+test('智谱：无 pre 的 .md-code 容器 + 语言未知 + 工具调用（带文字说明）→ 提取', () => {
+  global.window = { location: { href: 'https://chatglm.cn/main/alltoolsdetail?lang=zh' } };
+  const root = makeFakeRoot({
+    textOnly: '这是你的页面：',
+    codeText: 'await write("hello.html", "<h1>hi</h1>")',
+    langAttr: null,
+    hasPre: false,
+  });
+  const blocks = getJsCodeBlocksFromMarkdown(root);
+  assert.deepStrictEqual(blocks, ['await write("hello.html", "<h1>hi</h1>")']);
+});
+
+test('智谱：无 pre 的 .md-code 容器 + 语言未知 + 工具调用（纯代码）→ 提取', () => {
+  global.window = { location: { href: 'https://chatglm.cn/main/alltoolsdetail?lang=zh' } };
+  const root = makeFakeRoot({
+    textOnly: '',
+    codeText: 'await read("a.txt")',
+    langAttr: null,
+    hasPre: false,
+  });
+  const blocks = getJsCodeBlocksFromMarkdown(root);
+  assert.deepStrictEqual(blocks, ['await read("a.txt")']);
+});
+
+test('智谱：语言未知 + 普通代码（非工具调用）→ 不提取', () => {
+  global.window = { location: { href: 'https://chatglm.cn/main/alltoolsdetail?lang=zh' } };
+  const root = makeFakeRoot({
+    textOnly: '',
+    codeText: 'console.log(1)',
+    langAttr: null,
+    hasPre: false,
+  });
+  const blocks = getJsCodeBlocksFromMarkdown(root);
+  assert.deepStrictEqual(blocks, []);
+});
+
+test('智谱：语言未知 + MCP 工具调用（mcp 前缀）→ 提取', () => {
+  global.window = { location: { href: 'https://chatglm.cn/main/alltoolsdetail?lang=zh' } };
+  const root = makeFakeRoot({
+    textOnly: '',
+    codeText: 'log(await mcpListServers());',
+    langAttr: null,
+    hasPre: true,
+  });
+  const blocks = getJsCodeBlocksFromMarkdown(root);
+  assert.strictEqual(blocks.length, 1, 'MCP 前缀工具调用应被提取');
+});
+
+test('智谱：语言未知 + log 包裹 await 调用 → 提取', () => {
+  global.window = { location: { href: 'https://chatglm.cn/main/alltoolsdetail?lang=zh' } };
+  const root = makeFakeRoot({
+    textOnly: '',
+    codeText: 'log(await mcpGetTools("godot-ai"));',
+    langAttr: null,
+    hasPre: true,
+  });
+  const blocks = getJsCodeBlocksFromMarkdown(root);
+  assert.strictEqual(blocks.length, 1, 'log 包裹的 await 工具调用应被提取');
+});
+
+test('js 语言 + 带文字说明 → 不提取（保持原收紧行为）', () => {
+  global.window = { location: { href: 'https://chat.deepseek.com/' } };
+  const root = makeFakeRoot({
+    textOnly: '说明文字',
+    codeText: 'await bash("echo hi")',
+    langAttr: 'js',
+    hasPre: true,
+  });
+  const blocks = getJsCodeBlocksFromMarkdown(root);
+  assert.deepStrictEqual(blocks, []);
+});


### PR DESCRIPTION
## 描述

一组通用框架改进，扩展 Provider 能力并提升 SPA 平台下的自动发送与自动解析稳定性：

1. **Provider 发送扩展接口（`provider.triggerSend`）**：部分平台（如智谱清言）只接受 isTrusted=true 的真实输入，合成 click / 合成 KeyboardEvent 全部免疫。Provider 可声明自己的原生发送方式（经主进程 `sendInputEvent`），未声明的 Provider 走原有逻辑，完全向后兼容。
2. **流式稳定性双通道**：回复解析由单次 setTimeout 校验改为 mutation 驱动快照 + interval 兜底，并对"文本分支"同样做稳定性校验（修复流式中途提前标记已处理导致完整代码块永久漏检）；另加完成检测兜底轮询（每 2s 主动复查），覆盖长回复期间完成信号被丢弃导致永久不触发的问题。
3. **自定义 Provider 渲染进程加载**：此前渲染进程直接跳过自定义 Provider（页面内解析 / 发送拿不到其方法），现由主进程经 additionalArguments 注入 userData 路径，渲染进程据此加载并缓存。
4. **代码块识别增强**：无 `<pre>` 的代码容器兜底（如智谱 `.md-code`）；语言未知时代码以工具调用开头即视为工具脚本；MCP 工具识别（`await mcpXxx(` / `log(await xxx(`）。
5. **会话识别通用化**：会话 ID 提取与会话跳转 URL 改走 Provider（`extractSessionId` / `sessionUrlBase`），不再硬编码 DeepSeek 格式。

## 关联 Issue

无

## 变更类型

- [ ] Bug 修复（修复了一个问题）
- [x] 新功能（添加了非破坏性的功能）
- [ ] 破坏性变更（会导致现有功能无法正常工作）
- [ ] 文档更新
- [ ] 代码风格 / 重构
- [x] 测试

## 测试

- 全量测试 **262/262 通过**（官方基线 255 + 新增 7 例防回归用例：js-detector 6 例、自定义 Provider 渲染进程加载 1 例）
- 在 Windows 上实际运行验证（Electron + 智谱清言真实页面：自动发送、自动解析、长回复轮询、MCP 工具调用均已实测）
- 向后兼容：DeepSeek / Claude 无行为变化（未声明 triggerSend 走原逻辑；语言标签正常识别）
- [x] 在 Windows 上测试通过
- [x] 代码已检查，没有 lint 错误

## 截图（如果适用）

（无）

## 补充信息

改动文件（10）：`src/main/ipc.js`、`src/main/index.js`、`src/main/session-store.js`、`src/preload/api.js`、`src/preload/dom/chat-input.js`、`src/preload/dom/observer.js`、`src/preload/dom/js-detector.js`、`src/providers/custom/loader.js`、`test/preload/js-detector.test.js`、`test/main/providers.test.js`
